### PR TITLE
docs: correct authentication header in API docstring

### DIFF
--- a/src/embeddings_api/main.py
+++ b/src/embeddings_api/main.py
@@ -64,8 +64,8 @@ async def health_check() -> HealthResponse:
 async def generate_embeddings(request: GenerateRequest) -> GenerateResponse:
     """Generate embeddings for a list of texts.
 
-    Requires authentication via API key in the Authorization header:
-    `Authorization: Bearer <api_key>`
+    Requires authentication via API key in the X-API-Key header:
+    `X-API-Key: <api_key>`
     """
     if not embedding_service.is_loaded:
         raise HTTPException(


### PR DESCRIPTION
## Problema

A documentação do endpoint `/generate` está incorreta e inconsistente com a implementação real.

**Documentação atual (ERRADA):**
```python
"""
Requires authentication via API key in the Authorization header:
`Authorization: Bearer <api_key>`
"""
```

**Implementação real:**
```python
# src/embeddings_api/auth.py
api_key_header = APIKeyHeader(name="X-API-Key", auto_error=False)
```

## Mudança

Corrige a docstring para refletir o header correto:

```diff
- Requires authentication via API key in the Authorization header:
- `Authorization: Bearer <api_key>`
+ Requires authentication via API key in the X-API-Key header:
+ `X-API-Key: <api_key>`
```

## Impacto

### Positivo
- ✅ Documentação alinhada com implementação
- ✅ Desenvolvedores usarão o header correto
- ✅ Swagger/OpenAPI docs ficam corretos

### Nenhum Impacto em Código
- ✅ Apenas documentação (docstring)
- ✅ Não muda comportamento da API
- ✅ Não quebra compatibilidade

## Exemplo de Uso Correto

```bash
curl -X POST "$EMBEDDINGS_API_URL/generate" \
  -H "X-API-Key: $API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"texts": ["exemplo"]}' 
```

## Contexto

Esta correção faz parte de um conjunto de melhorias relacionadas:
- destaquesgovbr/infra#52 - Remoção de IAM auth requirement
- #1 - Issue para implementar rate limiting
- destaquesgovbr/data-platform#18 - Simplificação do client

## Checklist

- [x] Documentação corrigida
- [x] Alinhada com implementação em auth.py
- [ ] Pode ser merged independentemente