### PR TITLE
fix: desabilitar documentação Swagger/ReDoc em produção [V05]

### DIFF
--- a/src/embeddings_api/config.py
+++ b/src/embeddings_api/config.py
@@ -9,6 +9,9 @@ class Settings(BaseSettings):
     # API authentication
     api_key: str = "dev-api-key"
 
+    # Documentation
+    docs_enabled: bool = True
+
     # Model configuration
     model_name: str = "sentence-transformers/paraphrase-multilingual-mpnet-base-v2"
 

--- a/src/embeddings_api/main.py
+++ b/src/embeddings_api/main.py
@@ -9,6 +9,7 @@ from fastapi import Depends, FastAPI, HTTPException, Request, Response, status
 
 from . import __version__
 from .auth import verify_api_key
+from .config import Settings, settings
 from .embedding_service import embedding_service
 from .pubsub_handler import process_article
 from .schemas import ErrorResponse, GenerateRequest, GenerateResponse, HealthResponse
@@ -30,112 +31,129 @@ async def lifespan(app: FastAPI):
     logger.info("Shutting down Embeddings API...")
 
 
-app = FastAPI(
-    title="Embeddings API",
-    description="API for generating text embeddings using ML models",
-    version=__version__,
-    lifespan=lifespan,
-)
+def create_app(app_settings: Settings | None = None) -> FastAPI:
+    """Create and configure the FastAPI application.
 
+    Args:
+        app_settings: Settings instance. Uses global settings if not provided.
+    """
+    cfg = app_settings or settings
 
-@app.get(
-    "/health",
-    response_model=HealthResponse,
-    tags=["Health"],
-    summary="Health check endpoint",
-)
-async def health_check() -> HealthResponse:
-    """Check the health status of the API and model."""
-    return HealthResponse(
-        status="healthy",
-        model_loaded=embedding_service.is_loaded,
+    docs_url = "/docs" if cfg.docs_enabled else None
+    redoc_url = "/redoc" if cfg.docs_enabled else None
+    openapi_url = "/openapi.json" if cfg.docs_enabled else None
+
+    logger.info(f"API docs enabled: {cfg.docs_enabled}")
+
+    application = FastAPI(
+        title="Embeddings API",
+        description="API for generating text embeddings using ML models",
+        version=__version__,
+        lifespan=lifespan,
+        docs_url=docs_url,
+        redoc_url=redoc_url,
+        openapi_url=openapi_url,
     )
 
-
-@app.post(
-    "/generate",
-    response_model=GenerateResponse,
-    responses={
-        401: {"model": ErrorResponse, "description": "Unauthorized"},
-        422: {"model": ErrorResponse, "description": "Validation Error"},
-        500: {"model": ErrorResponse, "description": "Internal Server Error"},
-    },
-    tags=["Embeddings"],
-    summary="Generate embeddings for texts",
-    dependencies=[Depends(verify_api_key)],
-)
-async def generate_embeddings(request: GenerateRequest) -> GenerateResponse:
-    """Generate embeddings for a list of texts.
-
-    Requires authentication via API key in the X-API-Key header.
-    """
-    if not embedding_service.is_loaded:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Model not loaded",
+    @application.get(
+        "/health",
+        response_model=HealthResponse,
+        tags=["Health"],
+        summary="Health check endpoint",
+    )
+    async def health_check() -> HealthResponse:
+        """Check the health status of the API and model."""
+        return HealthResponse(
+            status="healthy",
+            model_loaded=embedding_service.is_loaded,
         )
 
-    try:
-        embeddings = embedding_service.generate(request.texts)
-        return GenerateResponse(
-            embeddings=embeddings,
-            model=embedding_service.model_name,
-            dimension=embedding_service.dimension,
-            count=len(embeddings),
-        )
-    except Exception as e:
-        logger.exception("Error generating embeddings")
-        raise HTTPException(
-            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-            detail=str(e),
-        ) from e
+    @application.post(
+        "/generate",
+        response_model=GenerateResponse,
+        responses={
+            401: {"model": ErrorResponse, "description": "Unauthorized"},
+            422: {"model": ErrorResponse, "description": "Validation Error"},
+            500: {"model": ErrorResponse, "description": "Internal Server Error"},
+        },
+        tags=["Embeddings"],
+        summary="Generate embeddings for texts",
+        dependencies=[Depends(verify_api_key)],
+    )
+    async def generate_embeddings(request: GenerateRequest) -> GenerateResponse:
+        """Generate embeddings for a list of texts.
+
+        Requires authentication via API key in the X-API-Key header.
+        """
+        if not embedding_service.is_loaded:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Model not loaded",
+            )
+
+        try:
+            embeddings = embedding_service.generate(request.texts)
+            return GenerateResponse(
+                embeddings=embeddings,
+                model=embedding_service.model_name,
+                dimension=embedding_service.dimension,
+                count=len(embeddings),
+            )
+        except Exception as e:
+            logger.exception("Error generating embeddings")
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail=str(e),
+            ) from e
+
+    @application.post(
+        "/process",
+        tags=["Pub/Sub"],
+        summary="Process Pub/Sub push message for embedding generation",
+    )
+    async def process_pubsub(request: Request) -> Response:
+        """Handle Pub/Sub push message from dgb.news.enriched.
+
+        No API key required — authenticated via Pub/Sub push OIDC token
+        verified by Cloud Run IAM.
+        """
+        try:
+            envelope = await request.json()
+        except Exception:
+            return Response(status_code=400, content="Invalid JSON")
+
+        message = envelope.get("message", {})
+        data_b64 = message.get("data")
+        if not data_b64:
+            return Response(status_code=400, content="No data")
+
+        try:
+            payload = json.loads(base64.b64decode(data_b64))
+        except Exception:
+            return Response(status_code=400, content="Invalid data encoding")
+
+        unique_id = payload.get("unique_id")
+        if not unique_id:
+            return Response(status_code=400, content="Missing unique_id")
+
+        trace_id = message.get("attributes", {}).get("trace_id", "")
+        logger.info(f"Processing embedding for {unique_id} (trace={trace_id})")
+
+        try:
+            result = process_article(unique_id)
+            logger.info(f"Result for {unique_id}: {result['status']}")
+            return Response(status_code=200, content=json.dumps(result))
+        except Exception as e:
+            logger.error(f"Error processing {unique_id}: {e}", exc_info=True)
+            return Response(status_code=200, content=f"ACK (error: {e})")
+
+    return application
 
 
-@app.post(
-    "/process",
-    tags=["Pub/Sub"],
-    summary="Process Pub/Sub push message for embedding generation",
-)
-async def process_pubsub(request: Request) -> Response:
-    """Handle Pub/Sub push message from dgb.news.enriched.
-
-    No API key required — authenticated via Pub/Sub push OIDC token
-    verified by Cloud Run IAM.
-    """
-    try:
-        envelope = await request.json()
-    except Exception:
-        return Response(status_code=400, content="Invalid JSON")
-
-    message = envelope.get("message", {})
-    data_b64 = message.get("data")
-    if not data_b64:
-        return Response(status_code=400, content="No data")
-
-    try:
-        payload = json.loads(base64.b64decode(data_b64))
-    except Exception:
-        return Response(status_code=400, content="Invalid data encoding")
-
-    unique_id = payload.get("unique_id")
-    if not unique_id:
-        return Response(status_code=400, content="Missing unique_id")
-
-    trace_id = message.get("attributes", {}).get("trace_id", "")
-    logger.info(f"Processing embedding for {unique_id} (trace={trace_id})")
-
-    try:
-        result = process_article(unique_id)
-        logger.info(f"Result for {unique_id}: {result['status']}")
-        return Response(status_code=200, content=json.dumps(result))
-    except Exception as e:
-        logger.error(f"Error processing {unique_id}: {e}", exc_info=True)
-        return Response(status_code=200, content=f"ACK (error: {e})")
+app = create_app()
 
 
 if __name__ == "__main__":
     import uvicorn
-
-    from .config import settings
 
     uvicorn.run(app, host=settings.host, port=settings.port)

--- a/src/embeddings_api/pubsub_handler.py
+++ b/src/embeddings_api/pubsub_handler.py
@@ -10,7 +10,7 @@ import json
 import logging
 import os
 import uuid
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
 import psycopg2
 
@@ -34,7 +34,8 @@ def fetch_article(unique_id: str) -> dict | None:
     try:
         with conn.cursor() as cur:
             cur.execute(
-                "SELECT id, title, summary, content, content_embedding FROM news WHERE unique_id = %s",
+                "SELECT id, title, summary, content, content_embedding"
+                " FROM news WHERE unique_id = %s",
                 (unique_id,),
             )
             row = cur.fetchone()
@@ -63,7 +64,7 @@ def update_embedding(news_id: int, embedding: list[float]) -> None:
                     embedding_generated_at = %s
                 WHERE id = %s
                 """,
-                (embedding, datetime.now(timezone.utc), news_id),
+                (embedding, datetime.now(UTC), news_id),
             )
             conn.commit()
     except Exception:
@@ -85,7 +86,7 @@ def publish_embedded_event(unique_id: str, embedding_dim: int) -> None:
         client = pubsub_v1.PublisherClient()
         message = {
             "unique_id": unique_id,
-            "embedded_at": datetime.now(timezone.utc).isoformat(),
+            "embedded_at": datetime.now(UTC).isoformat(),
             "embedding_dim": embedding_dim,
         }
         client.publish(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,67 @@
 """Tests for the Embeddings API endpoints."""
 
+from fastapi.testclient import TestClient
+
+from src.embeddings_api.config import Settings
+from src.embeddings_api.main import create_app
+
+
+class TestDocsDisabled:
+    """Tests for docs endpoints when DOCS_ENABLED=false."""
+
+    def test_swagger_returns_404(self):
+        """GET /docs should return 404 when docs is disabled."""
+        app = create_app(Settings(docs_enabled=False))
+        client = TestClient(app)
+        response = client.get("/docs")
+        assert response.status_code == 404
+
+    def test_redoc_returns_404(self):
+        """GET /redoc should return 404 when docs is disabled."""
+        app = create_app(Settings(docs_enabled=False))
+        client = TestClient(app)
+        response = client.get("/redoc")
+        assert response.status_code == 404
+
+    def test_openapi_json_returns_404(self):
+        """GET /openapi.json should return 404 when docs is disabled."""
+        app = create_app(Settings(docs_enabled=False))
+        client = TestClient(app)
+        response = client.get("/openapi.json")
+        assert response.status_code == 404
+
+    def test_health_still_works(self):
+        """GET /health should still work when docs is disabled."""
+        app = create_app(Settings(docs_enabled=False))
+        client = TestClient(app)
+        response = client.get("/health")
+        assert response.status_code == 200
+
+
+class TestDocsEnabled:
+    """Tests for docs endpoints when DOCS_ENABLED=true (default)."""
+
+    def test_swagger_returns_200(self):
+        """GET /docs should return 200 when docs is enabled."""
+        app = create_app(Settings(docs_enabled=True))
+        client = TestClient(app)
+        response = client.get("/docs")
+        assert response.status_code == 200
+
+    def test_redoc_returns_200(self):
+        """GET /redoc should return 200 when docs is enabled."""
+        app = create_app(Settings(docs_enabled=True))
+        client = TestClient(app)
+        response = client.get("/redoc")
+        assert response.status_code == 200
+
+    def test_openapi_json_returns_200(self):
+        """GET /openapi.json should return 200 when docs is enabled."""
+        app = create_app(Settings(docs_enabled=True))
+        client = TestClient(app)
+        response = client.get("/openapi.json")
+        assert response.status_code == 200
+
 
 class TestHealthEndpoint:
     """Tests for the /health endpoint."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,24 @@
+"""Tests for application settings."""
+
+from src.embeddings_api.config import Settings
+
+
+class TestDocsEnabledSetting:
+    """Tests for the docs_enabled configuration field."""
+
+    def test_docs_enabled_defaults_to_true(self):
+        """Without DOCS_ENABLED env var, docs should be enabled by default."""
+        settings = Settings()
+        assert settings.docs_enabled is True
+
+    def test_docs_enabled_false_from_env(self, monkeypatch):
+        """DOCS_ENABLED=false should disable docs."""
+        monkeypatch.setenv("DOCS_ENABLED", "false")
+        settings = Settings()
+        assert settings.docs_enabled is False
+
+    def test_docs_enabled_true_from_env(self, monkeypatch):
+        """DOCS_ENABLED=true should enable docs."""
+        monkeypatch.setenv("DOCS_ENABLED", "true")
+        settings = Settings()
+        assert settings.docs_enabled is True

--- a/tests/test_pubsub_handler.py
+++ b/tests/test_pubsub_handler.py
@@ -7,10 +7,9 @@ fetch from PG, generate embedding locally, update PG, publish event.
 
 import base64
 import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
-
 
 # =============================================================================
 # Fixtures


### PR DESCRIPTION
## Summary

- Corrige vulnerabilidade **[V05]** do pentest CPQD (CVSS 6.5) — exposição pública de documentação técnica da embeddings-api
- Adiciona setting `docs_enabled` (default: `True`) controlado pela env var `DOCS_ENABLED`
- Extrai `create_app()` factory para configuração condicional de `/docs`, `/redoc`, `/openapi.json`
- Quando `DOCS_ENABLED=false`: endpoints de documentação retornam HTTP 404
- Em desenvolvimento local (default): documentação continua acessível normalmente

## Arquivos alterados

| Arquivo | Alteração |
|---|---|
| `src/embeddings_api/config.py` | Novo campo `docs_enabled: bool = True` |
| `src/embeddings_api/main.py` | Factory `create_app()` + condicional docs |
| `tests/test_api.py` | 7 novos testes (docs habilitada/desabilitada) |
| `tests/test_config.py` | 3 novos testes para o setting |

## Test plan

- [x] 46 testes passando (10 novos + 36 existentes)
- [x] Zero regressões
- [x] Lint limpo (`ruff check`)
- [ ] Validar deploy: `DOCS_ENABLED=false` → `/docs` retorna 404
- [ ] Validar deploy: endpoints `/health`, `/generate`, `/process` não afetados

**Ref:** Relatório CPQD INSPIRE-M7-Destaquesgovbr (pág. 25-27)
**Infra PR:** destaquesgovbr/infra — `fix/disable-embeddings-api-docs`

Closes #9