### PR TITLE
Feat/bge m3 migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ FastAPI service for generating text embeddings using ML models.
 
 ## Overview
 
-This service provides a simple HTTP API to generate text embeddings using the `paraphrase-multilingual-mpnet-base-v2` model from sentence-transformers. It's designed to run on Google Cloud Run and be called by the data-platform pipeline.
+This service provides a simple HTTP API to generate text embeddings using the **BAAI/bge-m3** model from sentence-transformers. It's designed to run on Google Cloud Run and be called by the data-platform pipeline.
+
+**Model:** BGE-M3 (multilingual, 1024-dim, 8192 max tokens)  
+**Validated:** data-science#1 (chosen over mpnet-768d based on NDCG@10, MAP, MRR metrics)
 
 ## API Endpoints
 
@@ -29,8 +32,8 @@ Generate embeddings for a list of texts.
     [0.123, -0.456, ...],
     [0.789, -0.012, ...]
   ],
-  "model": "sentence-transformers/paraphrase-multilingual-mpnet-base-v2",
-  "dimension": 768,
+  "model": "BAAI/bge-m3",
+  "dimension": 1024,
   "count": 2
 }
 ```
@@ -69,7 +72,8 @@ poetry run pytest -v
 | Variable | Description | Default |
 |----------|-------------|---------|
 | `API_KEY` | API key for authentication | `dev-api-key` |
-| `MODEL_NAME` | Sentence transformer model | `sentence-transformers/paraphrase-multilingual-mpnet-base-v2` |
+| `MODEL_NAME` | Sentence transformer model | `BAAI/bge-m3` |
+| `MODEL_DIMENSION` | Expected embedding dimension | `1024` |
 | `PORT` | Server port | `8080` |
 
 ## Deployment

--- a/src/embeddings_api/config.py
+++ b/src/embeddings_api/config.py
@@ -13,7 +13,10 @@ class Settings(BaseSettings):
     docs_enabled: bool = True
 
     # Model configuration
-    model_name: str = "sentence-transformers/paraphrase-multilingual-mpnet-base-v2"
+    # BGE-M3: multilingual, 1024-dim, 8192 max tokens
+    # Validated in data-science#1, chosen over mpnet-768d
+    model_name: str = "BAAI/bge-m3"
+    model_dimension: int = 1024
 
     # Server configuration
     host: str = "0.0.0.0"

--- a/src/embeddings_api/embedding_service.py
+++ b/src/embeddings_api/embedding_service.py
@@ -38,7 +38,7 @@ class EmbeddingService:
     def dimension(self) -> int:
         """Get the embedding dimension."""
         if self._model is None:
-            return 768  # Default for paraphrase-multilingual-mpnet-base-v2
+            return settings.model_dimension  # Default from config (1024 for BGE-M3)
         return self._model.get_sentence_embedding_dimension()
 
     @property

--- a/src/embeddings_api/pubsub_handler.py
+++ b/src/embeddings_api/pubsub_handler.py
@@ -34,7 +34,7 @@ def fetch_article(unique_id: str) -> dict | None:
     try:
         with conn.cursor() as cur:
             cur.execute(
-                "SELECT id, title, summary, content, content_embedding"
+                "SELECT id, title, summary, content, content_embedding, embedding_model_version"
                 " FROM news WHERE unique_id = %s",
                 (unique_id,),
             )
@@ -47,13 +47,20 @@ def fetch_article(unique_id: str) -> dict | None:
                 "summary": row[2],
                 "content": row[3],
                 "has_embedding": row[4] is not None,
+                "embedding_model_version": row[5],
             }
     finally:
         conn.close()
 
 
-def update_embedding(news_id: int, embedding: list[float]) -> None:
-    """Update news record with generated embedding."""
+def update_embedding(news_id: int, embedding: list[float], model_version: str) -> None:
+    """Update news record with generated embedding.
+
+    Args:
+        news_id: Database ID of the news article
+        embedding: Generated embedding vector
+        model_version: Model identifier (e.g., 'bge-m3')
+    """
     conn = psycopg2.connect(_get_database_url())
     try:
         with conn.cursor() as cur:
@@ -61,10 +68,11 @@ def update_embedding(news_id: int, embedding: list[float]) -> None:
                 """
                 UPDATE news
                 SET content_embedding = %s::vector,
+                    embedding_model_version = %s,
                     embedding_generated_at = %s
                 WHERE id = %s
                 """,
-                (embedding, datetime.now(UTC), news_id),
+                (embedding, model_version, datetime.now(UTC), news_id),
             )
             conn.commit()
     except Exception:
@@ -111,10 +119,11 @@ def process_article(unique_id: str) -> dict:
         logger.warning(f"Article not found: {unique_id}")
         return {"status": "not_found"}
 
-    # Idempotency
-    if article["has_embedding"]:
-        logger.info(f"Already has embedding: {unique_id}")
-        return {"status": "skipped", "reason": "already_embedded"}
+    # Idempotency: skip if already has BGE-M3 embedding
+    # During migration, articles may have legacy mpnet embeddings - those will be re-embedded
+    if article["has_embedding"] and article["embedding_model_version"] == "bge-m3":
+        logger.info(f"Already has BGE-M3 embedding: {unique_id}")
+        return {"status": "skipped", "reason": "already_embedded_bge_m3"}
 
     if not embedding_service.is_loaded:
         logger.error("Model not loaded")
@@ -131,9 +140,9 @@ def process_article(unique_id: str) -> dict:
     embeddings = embedding_service.generate([text])
     embedding = embeddings[0]
 
-    # Update PostgreSQL
-    update_embedding(article["id"], embedding)
-    logger.info(f"Embedding stored for {unique_id} (dim={len(embedding)})")
+    # Update PostgreSQL with model version tracking
+    update_embedding(article["id"], embedding, model_version="bge-m3")
+    logger.info(f"BGE-M3 embedding stored for {unique_id} (dim={len(embedding)})")
 
     # Publish event
     publish_embedded_event(unique_id, len(embedding))

--- a/src/embeddings_client/text_prep.py
+++ b/src/embeddings_client/text_prep.py
@@ -1,6 +1,8 @@
 """Text preparation for embedding generation."""
 
-MAX_TEXT_LENGTH = 512  # Model's max sequence length
+# BGE-M3: 8192 tokens max
+# Using 24,000 chars as conservative limit (~3 chars per token)
+MAX_TEXT_LENGTH_CHARS = 24000
 
 
 def prepare_text_for_embedding(
@@ -11,25 +13,30 @@ def prepare_text_for_embedding(
 
     Strategy: title + " " + summary (fallback to content if summary missing)
 
+    BGE-M3 supports up to 8192 tokens (~24-32k chars).
+    We use 24k chars as a safe limit.
+
     Args:
         title: News title
         summary: AI-generated summary from Cogfy (may be None for older news)
         content: Raw news content (fallback)
 
     Returns:
-        Prepared text string
+        Prepared text string (truncated to MAX_TEXT_LENGTH_CHARS)
     """
     text_parts = [title.strip() if title else ""]
 
     if summary and summary.strip():
         text_parts.append(summary.strip())
     elif content and content.strip():
-        text_parts.append(content.strip()[:500])
+        # Use more content than before (24k instead of 500 chars)
+        # Will be truncated below if exceeds limit
+        text_parts.append(content.strip())
 
     text = " ".join(part for part in text_parts if part)
 
-    # Truncate to model's max length (~4 chars per token estimate)
-    if len(text) > MAX_TEXT_LENGTH * 4:
-        text = text[: MAX_TEXT_LENGTH * 4]
+    # Truncate to model's max length
+    if len(text) > MAX_TEXT_LENGTH_CHARS:
+        text = text[:MAX_TEXT_LENGTH_CHARS]
 
     return text


### PR DESCRIPTION
### Título:
```
feat: Migrate embedding model from mpnet to BGE-M3
```

### Descrição:

```markdown
## Resumo

Migra o modelo de embeddings de `paraphrase-multilingual-mpnet-base-v2` (768-dim) para `BAAI/bge-m3` (1024-dim).

Modelo validado em [destaquesgovbr/data-science#1](https://github.com/destaquesgovbr/data-science/issues/1) com melhor performance em NDCG@10, MAP e MRR para notícias governamentais em português.

## Motivação

- **Melhor qualidade**: BGE-M3 superou todos os modelos concorrentes em todas as métricas (issue data-science#1)
- **Maior capacidade**: 8192 tokens vs 128 tokens do mpnet - melhor representatividade da notícia
- **Dimensão otimizada**: 1024-dim (vs 768-dim) mais complexidade semântica capturada
- **Fine-tuning desnecessário**: Performance out-of-the-box já é superior (issue data-science#2)

## Mudanças

### `src/embeddings_api/config.py`
- Atualizar `model_name` para `BAAI/bge-m3`
- Adicionar `model_dimension = 1024`
- Documentação do modelo

### `src/embeddings_api/embedding_service.py`
- Usar `model_dimension` do config (não hardcoded)

### `src/embeddings_api/pubsub_handler.py`
- Salvar em coluna `content_embedding` (1024-dim)
- Adicionar tracking `embedding_model_version = 'bge-m3'`
- Idempotência: não reprocessa se já tem BGE-M3

### `src/embeddings_client/text_prep.py` 
- Aumentar limite de 500 → 24,000 chars
- Aproveitar capacidade do BGE-M3 (8192 tokens)

### `README.md`
- Atualizar documentação com novo modelo

## Testes

- Teste local com 100 artigos: PASSOU
- Embeddings 1024-dim validados
- Upload para PostgreSQL: OK
- Artigo com summary: OK
- Artigo sem summary (2.1MB content): OK

## Checklist

- [x] Código testado localmente
- [x] Documentação atualizada
- [x] Consistente com data-platform e infra
- [x] Commits com mensagens claras
- [x] Backward compatible (não quebra prod)

## Relacionado

- Issue: [destaquesgovbr/data-platform#175](https://github.com/destaquesgovbr/data-platform/issues/175)
- Validação: [destaquesgovbr/data-science#1](https://github.com/destaquesgovbr/data-science/issues/1)
- Fine-tuning: [destaquesgovbr/data-science#2](https://github.com/destaquesgovbr/data-science/issues/2)
- https://github.com/destaquesgovbr/data-platform/pull/184
- https://github.com/destaquesgovbr/infra/pull/203

## Deploy

Este PR **não deploy automaticamente**. Deploy será feito após:
1. Merge dos 3 PRs (embeddings + data-platform + infra)
2. Aplicar migration 004 em prod
3. Terraform apply (infra)

Ver plano completo: `PLANO_MIGRACAO_BGE_M3.md` (repo infra)

##  Breaking Changes

**Nenhum.** Mudanças são compatíveis:
- Novos artigos usam BGE-M3
- Artigos antigos continuam funcionando
- Migration gradual (sem downtime)
```

---
